### PR TITLE
base: Add Multi usb controller for Asus devices

### DIFF
--- a/core/res/res/values/voltage_config.xml
+++ b/core/res/res/values/voltage_config.xml
@@ -164,5 +164,8 @@
     <!-- List of system apps that are allowed to be locked with app lock.
           Use with extreme caution. -->
     <string-array name="config_appLockAllowedSystemApps" translatable="false" />
+	
+    <!-- Switch USB controller on Asus ROG devices-->
+    <bool name="config_switchUsbController">false</bool>	
 
 </resources>

--- a/core/res/res/values/voltage_symbols.xml
+++ b/core/res/res/values/voltage_symbols.xml
@@ -151,5 +151,8 @@
     <!-- App lock -->
     <java-symbol type="string" name="unlock_application" />
     <java-symbol type="array" name="config_appLockAllowedSystemApps" />
+	
+    <!-- Switch USB controller on Asus ROG devices-->
+    <java-symbol type="bool" name="config_switchUsbController" />	
 
 </resources>

--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
@@ -216,6 +216,16 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
 
     private static UsbDeviceLogger sEventLogger;
 
+    /* Omni add-on */
+    private static boolean mUseMultiUsbController;
+    private static String udc_change;
+    private static final long FUNCTION_UDC_SWITCH = 128;
+    private static final String USB_CONTROLLER_PROPERTY = "sys.usb.controller";
+    private static final String UDC1_MODE = "/sys/devices/platform/soc/a600000.ssusb/mode";
+    private static final String UDC2_MODE = "/sys/devices/platform/soc/a800000.ssusb/mode";
+    private static final String UDC1_NAME_MATCH = "DEVPATH=/devices/platform/soc/a600000.ssusb/a600000.dwc3";
+    private static final String UDC2_NAME_MATCH = "DEVPATH=/devices/platform/soc/a800000.ssusb/a800000.dwc3";
+
     static {
         sDenyInterfaces = new HashSet<>();
         sDenyInterfaces.add(UsbConstants.USB_CLASS_AUDIO);
@@ -263,6 +273,17 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
                 mHandler.removeMessages(MSG_ACCESSORY_HANDSHAKE_TIMEOUT);
                 mHandler.setStartAccessoryTrue();
                 startAccessoryMode();
+            }
+            if (mUseMultiUsbController) {
+                String udcname = event.get("UDC_NAME");
+                if (udcname != null) {
+                    String controller = SystemProperties.get(USB_CONTROLLER_PROPERTY);
+                    if (!controller.equals(udcname)) {
+                        String unused = udc_change = udcname;
+                        setCurrentFunctions(FUNCTION_UDC_SWITCH);
+                    }
+                    Slog.i(TAG, "Controller=" + controller + " UDC_NAME=" + udcname);
+                }
             }
         }
     }
@@ -391,12 +412,20 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
         mContext.registerReceiver(languageChangedReceiver,
                 new IntentFilter(Intent.ACTION_LOCALE_CHANGED));
 
+        mUseMultiUsbController = mContext.getResources().getBoolean(
+                                    com.android.internal.R.bool.config_switchUsbController);
+
         // Watch for USB configuration changes
         mUEventObserver = new UsbUEventObserver();
         mUEventObserver.startObserving(USB_STATE_MATCH);
         mUEventObserver.startObserving(ACCESSORY_START_MATCH);
 
         sEventLogger = new UsbDeviceLogger(DUMPSYS_LOG_BUFFER, "UsbDeviceManager activity");
+
+        if (mUseMultiUsbController) {
+            mUEventObserver.startObserving(UDC1_NAME_MATCH);
+            mUEventObserver.startObserving(UDC2_NAME_MATCH);
+        }
     }
 
     UsbProfileGroupSettingsManager getCurrentSettings() {
@@ -1013,6 +1042,20 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
                     break;
                 case MSG_SET_CURRENT_FUNCTIONS:
                     long functions = (Long) msg.obj;
+                    if (mUseMultiUsbController) {
+                        if (FUNCTION_UDC_SWITCH == functions) {
+                            SystemProperties.set(USB_CONTROLLER_PROPERTY, udc_change);
+                            if (!mScreenLocked) {
+                                long unlockfunctions = mScreenUnlockedFunctions;
+                                if (unlockfunctions != 0) {
+                                    setEnabledFunctions(unlockfunctions, true);
+                                    break;
+                                }
+                            }
+                            setEnabledFunctions(0, true);
+                            break;
+                        }
+                    }
                     setEnabledFunctions(functions, false);
                     break;
                 case MSG_SET_SCREEN_UNLOCKED_FUNCTIONS:
@@ -1132,15 +1175,38 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
 
         protected void finishBoot() {
             if (mBootCompleted && mCurrentUsbFunctionsReceived && mSystemReady) {
+                boolean switchudc = false;
                 if (mPendingBootBroadcast) {
                     updateUsbStateBroadcastIfNeeded(getAppliedFunctions(mCurrentFunctions));
                     mPendingBootBroadcast = false;
+                }
+                if (mUseMultiUsbController) {
+                    String controller = SystemProperties.get(USB_CONTROLLER_PROPERTY);
+                    try {
+                        String usb1mode = FileUtils.readTextFile(new File(UDC1_MODE), 0, null).trim();
+                        String usb2mode = FileUtils.readTextFile(new File(UDC2_MODE), 0, null).trim();
+                        if ("peripheral".equals(usb1mode) && !"a600000.dwc3".equals(controller)) {
+                            switchudc = true;
+                            SystemProperties.set(USB_CONTROLLER_PROPERTY, "a600000.dwc3");
+                        } else if ("peripheral".equals(usb2mode) && !"a800000.dwc3".equals(controller)) {
+                            switchudc = true;
+                            SystemProperties.set(USB_CONTROLLER_PROPERTY, "a800000.dwc3");
+                        }
+                        String str = TAG;
+                        Slog.i(str, "usb1_mode=" + usb1mode + " usb2_mode=" + usb2mode + " controller=" + controller);
+                    } catch (IOException e) {
+                        Slog.e(TAG, "Error read usb mode", e);
+                    }
                 }
                 if (!mScreenLocked
                         && mScreenUnlockedFunctions != UsbManager.FUNCTION_NONE) {
                     setScreenUnlockedFunctions();
                 } else {
-                    setEnabledFunctions(UsbManager.FUNCTION_NONE, false);
+                    if (mUseMultiUsbController) {
+                        setEnabledFunctions(UsbManager.FUNCTION_NONE, switchudc);
+                    } else {
+                        setEnabledFunctions(UsbManager.FUNCTION_NONE, false);
+                    }
                 }
                 if (mCurrentAccessory != null) {
                     mUsbDeviceManager.getCurrentSettings().accessoryAttached(mCurrentAccessory);


### PR DESCRIPTION
All ROG devices have 2 usb port. We can use both for mtp, not only charger.

Change-Id: Ib9d8e1e6916eda4f3504c2e198841fb4c2b3fb43